### PR TITLE
:(

### DIFF
--- a/src/artikelverwaltung/component/suche_artikels/such_kriterien.ts
+++ b/src/artikelverwaltung/component/suche_artikels/such_kriterien.ts
@@ -42,7 +42,7 @@ import {log} from '../../../shared/shared';
                         * Eingaben werden validiert
                 -->
                 <!-- Template-Syntax:
-                     (submit)="find()"   fuer Output = Event Binding
+                     (submit)="findByBezeichnung()"   fuer Output = Event Binding
                                          d.h. Ereignis submit an find() anbinden
                                          oder on-submit="find"
                      Definition von Attributnamen gemaess HTML: Attribute names
@@ -55,14 +55,14 @@ import {log} from '../../../shared/shared';
                      form-group, row, form-control-label, btn, ...
                      http://v4-alpha.getbootstrap.com/components/forms -->
 
-                <form (submit)="find()" role="form">
+                <form (submit)="findByBezeichnung()" role="form">
                     <div class="form-group row">
                         <label for="bezeichnungInput"
                                class="col-sm-2 form-control-label">Bezeichnung</label>
                         <div class="col-sm-10">
                             <input id="bezeichnungInput"
                                 type="search"
-                                placeholder="Den Artikelnamen oder einen Teil davon eingeben"
+                                placeholder="Die Artikel-ID eingeben: "
                                 class="form-control"
                                 [(ngModel)]="bezeichnung">
                         </div>
@@ -106,7 +106,7 @@ export default class SuchKriterien {
      *         zu konsumieren.
      */
     @log
-    find(): boolean {
+    findByBezeichnung(): boolean {
         const suchkriterien: any = {bezeichnung: this.bezeichnung};
         console.log('suchkriterien=', suchkriterien);
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,5 +38,5 @@ export const BASE_URI: string = `${SCHEME}://${SERVERNAME}:${PORT}${BASE_PATH}`;
  * Pfad f&uuml;r den Zugriff auf B&uuml;cher, ausgehend von der Basis-URI.
  */
 export const PATH_KUNDEN: string = `kunden`;
-export const PATH_ARTIKELS: string = `artikels`;
+export const PATH_ARTIKELS: string = `katalog`;
 export const PATH_REGISTRIERUNG: string = `registrierung`;


### PR DESCRIPTION
Konstante PATH_ARTIKELS und such_kriterien.ts geändert. Nun greift es
auf die Klasse Katalog zu. Angesprochene Methode ist findByBezeichnung.
Eigentlich gibt's keine Fehler laut gulp ts und Seite lädt ganz normal.